### PR TITLE
improve type stability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dimensionless"
 uuid = "a24885ee-f44e-4313-a031-cb477fdea68a"
 authors = ["Martin Kosch"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/dim_basis.jl
+++ b/src/dim_basis.jl
@@ -1,6 +1,6 @@
 # Helper Unions
-QuantityOrUnits = Union{Unitful.AbstractQuantity,Unitful.Units}
-QuantityOrUnitlike = Union{Unitful.AbstractQuantity,Unitful.Unitlike}
+const QuantityOrUnits = Union{Unitful.AbstractQuantity,Unitful.Units}
+const QuantityOrUnitlike = Union{Unitful.AbstractQuantity,Unitful.Unitlike}
 
 """
     DimBasis(basis_vectors...) -> DimBasis
@@ -8,19 +8,20 @@ QuantityOrUnitlike = Union{Unitful.AbstractQuantity,Unitful.Unitlike}
 Create a dimensional basis for a number of `basis_vectors` (quantities, units or dimensions).
 A string identifier can optionally be added to each basis vector. 
 """
-struct DimBasis{T,N}
+struct DimBasis{T,N,BD,DM}
     basis_vectors::T
     basis_vector_names::N
-    basis_dims
-    dim_mat
+    basis_dims::BD
+    dim_mat::DM
 
     function DimBasis(basis_vectors::T, basis_vector_names::N=nothing) where {
-        T<:AbstractVector{<:QuantityOrUnitlike}} where {
-        N<:Union{Nothing,AbstractVector{<:AbstractString}}}
+        T<:AbstractVector,N<:Union{Nothing,<:AbstractVector{<:AbstractString}}}
         basis_dims = unique_dims(basis_vectors...)
         dim_mat = dim_matrix(basis_dims, basis_vectors...)
         check_basis(dim_mat)
-        return new{T,N}(basis_vectors, basis_vector_names, basis_dims, dim_mat)
+        return new{T,N,typeof(basis_dims),typeof(dim_mat)}(
+            basis_vectors, basis_vector_names, basis_dims, dim_mat,
+        )
     end
 end
 
@@ -37,10 +38,7 @@ end
 # Do not broadcast DimBasis
 Base.Broadcast.broadcastable(basis::DimBasis) = Ref(basis)
 
-# Helper Types
-QuantityDimBasis = DimBasis{<:AbstractVector{<:Unitful.AbstractQuantity}}
-
-NamedDimBase = DimBasis{T,<:AbstractVector{<:AbstractString}} where {T}
+const NamedDimBase = DimBasis{T,<:AbstractVector{<:AbstractString}} where {T}
 
 """
     unique_dims(all_values...)
@@ -52,7 +50,8 @@ function unique_dims(all_values::Vararg{Unitful.Dimensions})
     for dims in all_values
         union!(basis_dims, typeof.(typeof(dims).parameters[1]))
     end
-    return basis_dims
+    dtype = mapreduce(typeof, (a,b) -> Union{a,b}, basis_dims)
+    return convert(Vector{dtype}, basis_dims)
 end
 
 unique_dims(all_values::Vararg{QuantityOrUnits}) =
@@ -63,8 +62,8 @@ unique_dims(all_values::Vararg{QuantityOrUnits}) =
 
 Return the dimensional matrix for a set of basis dimensions `basis_dims` and `all_values`, a set of quantities, units or dimensions.
 """
-function dim_matrix(basis_dims::Array{Type{<:Unitful.Dimension}}, all_values::Vararg{Unitful.Dimensions})
-    dim_mat = zeros(Rational, length(basis_dims), length(all_values))
+function dim_matrix(basis_dims::AbstractArray, all_values::Vararg{Unitful.Dimensions})
+    dim_mat = zeros(Rational{Int}, length(basis_dims), length(all_values))
     for (dimension_ind, dims) in enumerate(all_values)
         for dimension in typeof(dims).parameters[1]
             basis_dim_ind = findfirst(x -> isa(dimension, x), basis_dims)
@@ -77,7 +76,7 @@ function dim_matrix(basis_dims::Array{Type{<:Unitful.Dimension}}, all_values::Va
     return dim_mat
 end
 
-dim_matrix(basis_dims::Array{Type{<:Unitful.Dimension}}, all_values::Vararg{QuantityOrUnits}) =
+dim_matrix(basis_dims::AbstractArray, all_values::Vararg{QuantityOrUnits}) =
     dim_matrix(basis_dims, dimension.(all_values)...)
 
 """

--- a/src/dim_basis_ops.jl
+++ b/src/dim_basis_ops.jl
@@ -30,7 +30,7 @@ num_of_dimless(all_vars::Vararg{Pair{<:AbstractString,<:QuantityOrUnitlike}}) =
 
 Return the scalar, dimensionless factor that a dimensionless value has to be multiplied with in order to translate it into the given `unit` in the specified `basis`. 
 """
-function fac_dimful(unit::Unitful.Units, basis::QuantityDimBasis)
+function fac_dimful(unit::Unitful.Units, basis::DimBasis)
     dim_vec = dim_matrix(basis.basis_dims, dimension(unit))
     fac = prod(basis.basis_vectors .^ (basis.dim_mat \ dim_vec))
     return ustrip(uconvert(unit, fac))
@@ -41,7 +41,7 @@ end
 
 Make a `quantity` dimensionless using a dimensional `basis`.
 """
-function dimless(quantity::Unitful.AbstractQuantity, basis::QuantityDimBasis)
+function dimless(quantity::Unitful.AbstractQuantity, basis::DimBasis)
     fac = fac_dimful(unit(quantity), basis)
     return ustrip(quantity) / fac
 end
@@ -51,7 +51,7 @@ end
 
 Restore the `unit`s of a dimensionless `value` using a dimensional `basis`.
 """
-function dimful(value, unit::Unitful.Units, basis::QuantityDimBasis)
+function dimful(value, unit::Unitful.Units, basis::DimBasis)
     fac = fac_dimful(unit, basis)
     return value * fac * unit
 end
@@ -61,7 +61,7 @@ end
 
 Return the factor that is needed to transform specified dimensions `dims` from a current `basis` to a `new_basis`.
 """
-function current_to_new_fac(dims::Unitful.Dimensions, basis::QuantityDimBasis, new_basis::QuantityDimBasis)
+function current_to_new_fac(dims::Unitful.Dimensions, basis::DimBasis, new_basis::DimBasis)
     dim_mat = dim_matrix(basis.basis_dims, dims)
     new_dim_mat = dim_matrix(new_basis.basis_dims, dims)
     basis_fac = prod(basis.basis_vectors .^ (basis.dim_mat \ dim_mat))
@@ -75,8 +75,8 @@ end
 
 Transform the specified quantity or unit `var` from a current `basis` to a `new_basis`.
 """
-change_basis(var::Unitful.AbstractQuantity, basis::QuantityDimBasis, new_basis::QuantityDimBasis) =
+change_basis(var::Unitful.AbstractQuantity, basis::DimBasis, new_basis::DimBasis) =
     var * current_to_new_fac(dimension(var), basis, new_basis)
 
-change_basis(var::Unitful.Units, basis::QuantityDimBasis, new_basis::QuantityDimBasis) =
+change_basis(var::Unitful.Units, basis::DimBasis, new_basis::DimBasis) =
     current_to_new_fac(dimension(var), basis, new_basis)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,8 @@ end
     dim_less = dimless.(vars, dimless_dimful_basis)
     @test dimful.(dim_less, [u"A/m^2", u"nm", u"K"], dimless_dimful_basis) == vars
 
+    @test dimless(1u"A", dimless_dimful_basis) ≈ 1000
+
     # Test counting of dimensions and dimensionless variables for named basis
     quantities_named = ["a" => 100.0u"m", "b" => 100u"kg", "c" => 0u"s"]
     units_named = [Pair(var.first, unit(var.second)) for var in quantities_named]


### PR DESCRIPTION
Hi, thanks for this cool package.

This PR makes the following improvements for type stability.  This helps the compiler infer the return type of functions improving performance in some cases (also it just helps to make things a lot cleaner if you are using this package and trying to find type stability issues in your own code).  This includes the following changes
- `DimBasis` is now a fully concrete type, simply by adding two additional type parametrs.
- `unique_dims` now infers an exact union type.  This may make it possible for the compiler to perform "union splitting", i.e. rendering the use of `basis_dims` effectively type stable.
- `dim_matrix` now returns a matrix of element type `Rational{Int}` instead of `Rational`, i.e. a concrete type.
- Some argument type assertions have been loosened to accommodate the above. 